### PR TITLE
Replace `crossbeam_utils::Backoff` by spin loops and manual backoff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/wyfo/swap-buffer-queue"
 [features]
 default = ["futures"]
 futures = ["std", "dep:futures"]
-std = ["crossbeam-utils/std"]
+std = []
 write = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ Here is the crossbeam benchmark [forked](https://github.com/wyfo/crossbeam/tree/
 
 | benchmark     | crossbeam | swap-buffer-queue |
 |---------------|-----------|-------------------|
-| bounded1_mpsc | 1.545s    | 1.341s            |
-| bounded1_spsc | 1.652s    | 1.138s            |
-| bounded_mpsc  | 0.362s    | 0.178s            |
-| bounded_seq   | 0.190s    | 0.156s            |
-| bounded_spsc  | 0.115s    | 0.139s            |
+| bounded1_mpsc | 1.545s    | 1.763s            |
+| bounded1_spsc | 1.652s    | 1.000s            |
+| bounded_mpsc  | 0.362s    | 0.137s            |
+| bounded_seq   | 0.190s    | 0.114s            |
+| bounded_spsc  | 0.115s    | 0.092s            |
 
 However, a large enough capacity is required to reach maximum performance; otherwise, high contention scenario may be penalized.
 This is because the algorithm put all the contention on a single atomic integer (instead of two for crossbeam).

--- a/src/loom.rs
+++ b/src/loom.rs
@@ -3,9 +3,10 @@ pub(crate) use std::sync::atomic;
 #[cfg(not(all(loom, test)))]
 #[cfg(feature = "std")]
 pub(crate) use std::sync::Mutex;
-#[rustfmt::skip]
 #[cfg(not(all(loom, test)))]
-pub(crate) use crossbeam_utils::Backoff;
+pub(crate) const SPIN_LIMIT: usize = 64;
+#[cfg(not(all(loom, test)))]
+pub(crate) const BACKOFF_LIMIT: usize = 6;
 
 #[cfg(all(loom, test))]
 pub(crate) use loom::sync::atomic;
@@ -13,19 +14,6 @@ pub(crate) use loom::sync::atomic;
 #[cfg(feature = "std")]
 pub(crate) use loom::sync::Mutex;
 #[cfg(all(loom, test))]
-pub(crate) struct Backoff;
+pub(crate) const SPIN_LIMIT: usize = 1;
 #[cfg(all(loom, test))]
-impl Backoff {
-    pub(crate) fn new() -> Self {
-        Self
-    }
-    pub(crate) fn snooze(&self) {
-        std::thread::yield_now()
-    }
-    pub(crate) fn spin(&self) {
-        std::hint::spin_loop()
-    }
-    pub(crate) fn is_completed(&self) -> bool {
-        true
-    }
-}
+pub(crate) const BACKOFF_LIMIT: usize = 1;


### PR DESCRIPTION
Thanks to this change, performances have been increased by 25% for crossbeam benchmark.